### PR TITLE
Hotfix

### DIFF
--- a/src/check_arguments.c
+++ b/src/check_arguments.c
@@ -1,11 +1,40 @@
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 #include "serveur.h"
 
 int		check_error_int(char *str, int value)
 {
 	dprintf(2, "%s %d not in range.\n", str, value);
 	return (1);
+}
+
+int		check_team_names_characters(t_arguments *args)
+{
+	u_int	i;
+	u_int	j;
+	int		error;
+	char	*name;
+
+	if (!args->teams)
+		return (1);
+	error = 0;
+	i = 0;
+	while (i < args->nb_team - 1)
+	{
+		j = 0;
+		name = args->teams[i].name;
+		while (name[j])
+		{
+			if (!isalnum(name[j]) && name[j] != '_' && name[j] != ' ')
+				++error;
+			++j;
+		}
+		++i;
+	}
+	if (error)
+		dprintf(2, "Some team have invalid character in name\n");
+	return (error);
 }
 
 int		check_team_names(t_arguments *args)
@@ -53,6 +82,9 @@ int		check_arguments(t_arguments *args, int error)
 		dprintf(2, "No team provided\n");
 	}
 	else
+	{
 		error += check_team_names(args);
+		error += check_team_names_characters(args);
+	}
 	return (error);
 }

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -4,16 +4,9 @@
 
 void	rm_teams(t_team **teams, int *nb_team)
 {
+	*nb_team = 0;
 	if (!*teams)
-	{
-		*nb_team = 0;
 		return ;
-	}
-	while (*nb_team > 0)
-	{
-		--(*nb_team);
-		free(((*teams)[*nb_team]).name);
-	}
 	free(*teams);
 	*teams = NULL;
 }

--- a/src/do_write.c
+++ b/src/do_write.c
@@ -2,28 +2,53 @@
 #include <unistd.h>
 #include "serveur.h"
 
-void	do_write(t_zappy *var, t_server *serv, int fd)
+int		do_write_extended_buffer(t_player *p)
 {
-	char		*str;
-	t_player	*p;
+	char	*str;
+	size_t	len;
+	size_t	ret;
 
-	(void)serv;
-	p = &var->players[fd];
+	while (p->snd.lst.size)
+	{
+		str = pop_msg(&p->snd.lst);
+		len = strlen(str);
+		ret = write(p->id, str, len);
+		if (ret != len)
+			return (rearrange_message_queue(p, ret, 0));
+		free(str);
+	}
+	return (0);
+}
+
+int		do_write_normal_buffer(t_player *p)
+{
+	size_t	len;
+	size_t	ret;
+
 	while (p->snd.full || p->snd.read != p->snd.write ||
 			p->snd.buf[p->snd.write] != p->snd.pos)
 	{
-		write(fd, p->snd.buf[p->snd.read], strlen(p->snd.buf[p->snd.read]));
+		len = strlen(p->snd.buf[p->snd.read]);
+		ret = write(p->id, p->snd.buf[p->snd.read], len);
+		if (len != ret)
+			return (rearrange_message_queue(p, ret, 1));
 		p->snd.full = 0;
 		if (p->snd.read == p->snd.write)
 			update_pos_pointer(&p->snd);
 		p->snd.read = (p->snd.read + 1 == NB_SND) ? 0 : p->snd.read + 1;
 	}
-	while (p->snd.lst.size)
-	{
-		str = pop_msg(&p->snd.lst);
-		write(fd, str, strlen(str));
-		free(str);
-	}
-	if (p->status == FD_CLOSE)
+	return (0);
+}
+
+void	do_write(t_zappy *var, t_server *serv, int fd)
+{
+	int			ret_normal_buffer;
+	int			ret_extended_buffer;
+	t_player	*p;
+
+	p = &var->players[fd];
+	if (!(ret_normal_buffer = do_write_normal_buffer(p)))
+		ret_extended_buffer = do_write_extended_buffer(p);
+	if (!ret_normal_buffer && ! ret_extended_buffer && p->status == FD_CLOSE)
 		close_client(var, serv, fd);
 }

--- a/src/message_2.c
+++ b/src/message_2.c
@@ -1,4 +1,29 @@
+#include <string.h>
 #include "serveur.h"
+
+int		rearrange_message_queue(t_player *p, size_t len, int buffer)
+{
+	t_lst_head	tmp_head;
+	t_lst_elem	*tmp;
+
+	if (buffer)
+		memmove(p->snd.buf[p->snd.read], &(p->snd.buf[p->snd.read][len]),
+			SND_SIZE - len);
+	if (!p->snd.full && p->snd.lst.size)
+	{
+		tmp_head.size = p->snd.lst.size;
+		tmp_head.first = p->snd.lst.first;
+		tmp_head.last = p->snd.lst.last;
+		bzero(&p->snd.lst, sizeof(t_lst_head));
+		while (tmp_head.size)
+		{
+			tmp = lst_pop(&tmp_head, 0);
+			add_msg_to_player(p, tmp->content, 0, 0);
+			free(tmp);
+		}
+	}
+	return (1);
+}
 
 void	message_unknown_command(t_player *p)
 {

--- a/src/message_2.c
+++ b/src/message_2.c
@@ -3,23 +3,26 @@
 
 int		rearrange_message_queue(t_player *p, size_t len, int buffer)
 {
+	char		*str;
 	t_lst_head	tmp_head;
 	t_lst_elem	*tmp;
 
 	if (buffer)
-		memmove(p->snd.buf[p->snd.read], &(p->snd.buf[p->snd.read][len]),
-			SND_SIZE - len);
+	{
+		str = p->snd.buf[p->snd.read];
+		memmove(str, &(str[len]), SND_SIZE - len);
+		if (p->snd.read == p->snd.write && !p->snd.full)
+			p->snd.pos = &str[strlen(str)];
+	}
 	if (!p->snd.full && p->snd.lst.size)
 	{
-		tmp_head.size = p->snd.lst.size;
-		tmp_head.first = p->snd.lst.first;
-		tmp_head.last = p->snd.lst.last;
+		memcpy(&tmp_head, &p->snd.lst, sizeof(t_lst_head));
 		bzero(&p->snd.lst, sizeof(t_lst_head));
 		while (tmp_head.size)
 		{
 			tmp = lst_pop(&tmp_head, 0);
 			add_msg_to_player(p, tmp->content, 0, 0);
-			free(tmp);
+			lst_delete_elem(&tmp, free);
 		}
 	}
 	return (1);

--- a/src/read_arguments.c
+++ b/src/read_arguments.c
@@ -39,11 +39,12 @@ int		get_opt_string(t_main_arg const m_arg, int *i, t_arguments *args)
 	j = 0;
 	while (first < *i)
 	{
-		args->teams[j].name = strdup(m_arg.av[first]);
+		stpncpy(args->teams[j].name, m_arg.av[first], TEAM_LEN);
+		args->teams[j].name[TEAM_LEN] = '\0';
 		++first;
 		++j;
 	}
-	args->teams[j].name = strdup("GRAPHIC");
+	stpncpy(args->teams[j].name, "GRAPHIC", TEAM_LEN);
 	return (0);
 }
 

--- a/src/serveur.h
+++ b/src/serveur.h
@@ -15,6 +15,7 @@
 # define MAX_MAP	50
 # define MIN_TICK	1
 # define MAX_TICK	500
+# define TEAM_LEN	32
 
 /*
 ** client status
@@ -27,7 +28,7 @@
 # define FD_CLOSE	5
 
 /*
-** other define
+** buffer constants
 */
 # define NB_RCV		5
 # define RCV_SIZE	128

--- a/src/serveur.h
+++ b/src/serveur.h
@@ -118,6 +118,7 @@ char		*pop_msg(t_lst_head *head);
 /*
 ** src/message_2.c
 */
+int		rearrange_message_queue(t_player *p, size_t len, int buffer);
 void	message_unknown_command(t_player *p);
 void	message_command_format_error(t_player *p);
 void	message_unsupported_command(t_player *p);

--- a/src/structs.h
+++ b/src/structs.h
@@ -48,7 +48,6 @@ typedef struct			s_player
 	int			id;
 	int			inv[6];
 	int			coord[2];
-	int			fov;
 	int			pending_actions;
 	t_team		*team;
 	t_tstmp		timeofdeath;

--- a/src/structs.h
+++ b/src/structs.h
@@ -39,7 +39,7 @@ typedef struct			s_server
 
 typedef struct			s_team
 {
-	char		*name;
+	char		name[TEAM_LEN + 1];
 	int			remain;
 }						t_team;
 

--- a/test/src/args/check_arguments.c
+++ b/test/src/args/check_arguments.c
@@ -43,11 +43,30 @@ START_TEST(arg_check_arguments_duplicate_team_name)
 }
 END_TEST
 
+START_TEST(arg_check_arguments_invalid_team_name)
+{
+	t_arguments		args = {1234, 20, 30, 40, 50, 3, NULL};
+
+	args.teams = (t_team*)malloc(sizeof(t_team)*3);
+	strcpy(args.teams[0].name, "V4l1d 734M_N4m3");
+	strcpy(args.teams[1].name, "!nv@li!d-\"team\";name");
+	strcpy(args.teams[2].name, "toto");
+	ck_assert_int_eq(7, check_arguments(&args, 0));
+	ck_assert_int_eq(1234, args.port);
+	ck_assert_int_eq(20, args.width);
+	ck_assert_int_eq(30, args.height);
+	ck_assert_int_eq(40, args.nb_clients);
+	ck_assert_int_eq(50, args.tick);
+	ck_assert_uint_eq(3, args.nb_team);
+	rm_teams(&args.teams, (int *)&args.nb_team);
+}
+END_TEST
+
 START_TEST(arg_check_arguments_too_much)
 {
 	t_arguments		args = {123411, 120, 130, 340, 550, 112, NULL};
 
-	ck_assert_int_eq(6, check_arguments(&args, 0));
+	ck_assert_int_eq(7, check_arguments(&args, 0));
 }
 END_TEST
 
@@ -66,6 +85,7 @@ TCase*	arg_check_arguments(void)
 	check_arguments = tcase_create("check_arguments");
 	tcase_add_test(check_arguments, arg_check_arguments_valid);
 	tcase_add_test(check_arguments, arg_check_arguments_duplicate_team_name);
+	tcase_add_test(check_arguments, arg_check_arguments_invalid_team_name);
 	tcase_add_test(check_arguments, arg_check_arguments_too_much);
 	tcase_add_test(check_arguments, arg_check_arguments_too_few);
 	return (check_arguments);

--- a/test/src/args/check_arguments.c
+++ b/test/src/args/check_arguments.c
@@ -7,8 +7,6 @@ START_TEST(arg_check_arguments_valid)
 	t_arguments		args = {1234, 20, 30, 40, 50, 2, NULL};
 
 	args.teams = (t_team*)malloc(sizeof(t_team)*2);
-	args.teams[0].name = (char *)malloc(10);
-	args.teams[1].name = (char *)malloc(10);
 	strcpy(args.teams[0].name, "toto");
 	strcpy(args.teams[1].name, "tutu");
 	ck_assert_int_eq(0, check_arguments(&args, 0));
@@ -29,9 +27,6 @@ START_TEST(arg_check_arguments_duplicate_team_name)
 	t_arguments		args = {1234, 20, 30, 40, 50, 3, NULL};
 
 	args.teams = (t_team*)malloc(sizeof(t_team)*3);
-	args.teams[0].name = (char *)malloc(10);
-	args.teams[1].name = (char *)malloc(10);
-	args.teams[2].name = (char *)malloc(10);
 	strcpy(args.teams[0].name, "toto");
 	strcpy(args.teams[1].name, "tutu");
 	strcpy(args.teams[2].name, "toto");

--- a/test/src/args/get_opt_string.c
+++ b/test/src/args/get_opt_string.c
@@ -36,6 +36,22 @@ START_TEST(arg_get_opt_string_two_team_last)
 }
 END_TEST
 
+START_TEST(arg_get_opt_string_team_name_too_long)
+{
+	int					i = 0;
+	t_arguments			args;
+	char				*av[4] = {"-n", "What is the dullest element? Bohrium", NULL};
+	const t_main_arg	dummy = {2, (const char**)av};
+
+	bzero(&args, sizeof(t_arguments));
+	ck_assert_int_eq(0, get_opt_string(dummy, &i, &args));
+	ck_assert_int_eq(2, args.nb_team);
+	ck_assert_str_eq("What is the dullest element? Boh", args.teams[0].name);
+	ck_assert_str_eq("GRAPHIC", args.teams[1].name);
+	ck_assert_int_eq(2, i);
+}
+END_TEST
+
 START_TEST(arg_get_opt_string_no_team)
 {
 	int					i = 0;
@@ -57,6 +73,7 @@ TCase*	arg_get_opt_string(void)
 	arg_get_opt_string = tcase_create("get_opt_string");
 	tcase_add_test(arg_get_opt_string, arg_get_opt_string_two_team);
 	tcase_add_test(arg_get_opt_string, arg_get_opt_string_two_team_last);
+	tcase_add_test(arg_get_opt_string, arg_get_opt_string_team_name_too_long);
 	tcase_add_test(arg_get_opt_string, arg_get_opt_string_no_team);
 	return (arg_get_opt_string);
 }

--- a/test/src/cleanup/cleanup_game.c
+++ b/test/src/cleanup/cleanup_game.c
@@ -11,8 +11,6 @@ void	set_dummy_t_zappy(t_zappy *var)
 	var->board_size[1] = 10;
 	var->board = gen_board(var->board_size, 10, 10);
 	var->teams = (t_team *)malloc(sizeof(t_team) * 2);
-	var->teams[0].name = (char *)malloc(10);
-	var->teams[1].name = (char *)malloc(10);
 	strcpy(var->teams[0].name, "toto");
 	strcpy(var->teams[1].name, "tutu");
 	var->nb_team = 2;

--- a/test/src/cleanup/rm_team.c
+++ b/test/src/cleanup/rm_team.c
@@ -5,16 +5,11 @@
 START_TEST(rm_teams_two_team)
 {
 	t_team	*teams = NULL;
-	char	*team_names[2];
 	int	nb_team = 2;
 
 	teams = (t_team *)malloc(sizeof(t_team) * 2);
-	team_names[0] = (char *)malloc(10);
-	team_names[1] = (char *)malloc(10);
-	strcpy(team_names[0], "toto");
-	strcpy(team_names[1], "tutu");
-	teams[0].name = team_names[0];
-	teams[1].name = team_names[1];
+	strcpy(teams[0].name, "toto");
+	strcpy(teams[1].name, "tutu");
 	rm_teams(&teams, &nb_team);
 	ck_assert_uint_eq(0, nb_team);
 	ck_assert_ptr_eq(NULL, teams);

--- a/test/src/connexion/affect_team.c
+++ b/test/src/connexion/affect_team.c
@@ -9,9 +9,6 @@ void	dummy_t_zappy(t_zappy *var, t_player *p)
 	var->board_size[1] = 20;
 	var->teams = (t_team *)malloc(sizeof(t_team) * 3);
 	bzero(var->teams, sizeof(t_team) * 3);
-	var->teams[0].name = (char *)malloc(10);
-	var->teams[1].name = (char *)malloc(10);
-	var->teams[2].name = (char *)malloc(10);
 	strcpy(var->teams[0].name, "toto");
 	strcpy(var->teams[1].name, "tutu");
 	strcpy(var->teams[2].name, "GRAPHIC");

--- a/test/src/message/message.c
+++ b/test/src/message/message.c
@@ -9,5 +9,6 @@ Suite*	suite_message_test(void)
 	suite_add_tcase(s, message_update_pos_pointer());
 	suite_add_tcase(s, message_add_msg_to_player_lst());
 	suite_add_tcase(s, message_add_msg_to_player());
+	suite_add_tcase(s, message_rearrange_message_queue());
 	return (s);
 }

--- a/test/src/message/message_test.h
+++ b/test/src/message/message_test.h
@@ -4,5 +4,6 @@
 TCase*	message_update_pos_pointer(void);
 TCase*	message_add_msg_to_player_lst(void);
 TCase*	message_add_msg_to_player(void);
+TCase*	message_rearrange_message_queue(void);
 
 #endif

--- a/test/src/message/rearrange_message_queue.c
+++ b/test/src/message/rearrange_message_queue.c
@@ -1,0 +1,30 @@
+#include <check.h>
+#include "serveur.h"
+#include "test_dummies.h"
+
+START_TEST(message_rearrange_simple_queue)
+{
+	t_zappy		var;
+	t_player	*p = &var.players[5];
+
+	dummy_t_zappy_without_board(&var);
+	dummy_t_player(&var, p);
+	add_msg_to_player(p, "caca", 0, 1);
+	add_msg_to_player(p, "caca boudin", 0, 1);
+	add_msg_to_player(p, "crotte", 6, 1);
+	add_msg_to_player(p, "crotte de chien", 15, 1);
+	rearrange_message_queue(p, 17, 1);
+	ck_assert_str_eq(p->snd.buf[p->snd.read], "crotte\ncrotte de chien\n");
+	clean_msg_queue(p);
+	rm_teams(&var.teams, &var.nb_team);
+}
+END_TEST
+
+TCase*	message_rearrange_message_queue(void)
+{
+	TCase	*tc;
+
+	tc = tcase_create("rearrange_msg_queue");
+	tcase_add_test(tc, message_rearrange_simple_queue);
+	return (tc);
+}

--- a/test/src/message/rearrange_message_queue.c
+++ b/test/src/message/rearrange_message_queue.c
@@ -14,7 +14,28 @@ START_TEST(message_rearrange_simple_queue)
 	add_msg_to_player(p, "crotte", 6, 1);
 	add_msg_to_player(p, "crotte de chien", 15, 1);
 	rearrange_message_queue(p, 17, 1);
-	ck_assert_str_eq(p->snd.buf[p->snd.read], "crotte\ncrotte de chien\n");
+	add_msg_to_player(p, "caca", 4, 1);
+	ck_assert_str_eq(p->snd.buf[p->snd.read], "crotte\ncrotte de chien\ncaca\n");
+	clean_msg_queue(p);
+	rm_teams(&var.teams, &var.nb_team);
+}
+END_TEST
+
+START_TEST(message_rearrange_extend_queue)
+{
+	t_zappy		var;
+	t_player	*p = &var.players[5];
+
+	dummy_t_zappy_without_board(&var);
+	dummy_t_player(&var, p);
+	add_msg_to_player(p, "caca", 0, 1);
+	add_msg_to_player(p, "caca boudin", 0, 1);
+	add_msg_to_player(p, "crotte", 6, 1);
+	add_msg_to_player(p, "crotte de chien", 15, 1);
+	add_msg_to_player_lst(p, "LEERRROOOOYYY ", 14, 0);
+	add_msg_to_player_lst(p, "JJEEENNKKIINNKKSSSSS !", 23, 1);
+	rearrange_message_queue(p, 17, 1);
+	ck_assert_str_eq(p->snd.buf[p->snd.read], "crotte\ncrotte de chien\nLEERRROOOOYYY JJEEENNKKIINNKKSSSSS !\n");
 	clean_msg_queue(p);
 	rm_teams(&var.teams, &var.nb_team);
 }
@@ -26,5 +47,6 @@ TCase*	message_rearrange_message_queue(void)
 
 	tc = tcase_create("rearrange_msg_queue");
 	tcase_add_test(tc, message_rearrange_simple_queue);
+	tcase_add_test(tc, message_rearrange_extend_queue);
 	return (tc);
 }

--- a/test/src/test_dummies.c
+++ b/test/src/test_dummies.c
@@ -12,11 +12,11 @@ void	dummy_t_zappy_without_board(t_zappy *var)
 	var->nb_team = 3;
 	var->teams = (t_team *)malloc(sizeof(t_team) * 3);
 	bzero(var->teams, sizeof(t_team) * 3);
-	var->teams[0].name = strdup("toto");
+	strcpy(var->teams[0].name, "toto");
 	var->teams[0].remain = 0;
-	var->teams[1].name = strdup("tutu");
+	strcpy(var->teams[1].name, "tutu");
 	var->teams[1].remain = 0;
-	var->teams[2].name = strdup("GRAPHIC");
+	strcpy(var->teams[2].name, "GRAPHIC");
 	var->teams[2].remain = 0;
 	bzero(&var->actions.size, sizeof(t_lst_head));
 }


### PR DESCRIPTION
Always test the return of write...
Though this implementation is at it's best : if the first 'write' is the exacte length in the buffer, I won't detect it cause I don't re-run a select before second writing.
Is the solution to do just one write per loop ? Or do a new select before each write ?
I found the first one better.. but for now, it will do, we need to have a 'functionning' server for other to test their part with it.
